### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a reproducible problem in Astris.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈问题！请尽量提供完整信息，帮助我们定位并复现。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交前请确认
+      options:
+        - label: 我已搜索现有 issues，确认没有重复问题。
+          required: true
+        - label: 我在最新版（main 分支）或最近的发布版本上复现过此问题。
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 简要描述
+      description: 简要说明遇到的问题及其影响。
+      placeholder: 描述问题的概况……
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: 复现步骤
+      description: 清晰列出如何复现问题的步骤。
+      placeholder: |
+        1. …
+        2. …
+        3. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 预期行为
+      description: 描述你期望发生的结果。
+      placeholder: 应该发生什么？
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 描述实际发生的结果，并附上必要的截图或日志。
+      placeholder: 实际发生了什么？
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: 版本信息
+      description: 请提供 Astris 版本、平台（OS/架构）与运行特性（如 dev_native）。
+      placeholder: 例如：main (commit abc123)、Windows 11、dev_native
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 附加上下文
+      description: 其他信息、日志、崩溃堆栈等。
+      placeholder: 如有更多线索，请在此补充。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/astris-rs/astris/security/policy
+    about: 如果你发现安全问题，请按安全策略私下报告。

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,41 @@
+name: Docs improvement
+description: Request updates or additions to documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        文档对于分享知识至关重要，请提供足够的背景信息，便于我们更新内容。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交前请确认
+      options:
+        - label: 我已搜索现有 issues 和文档，确认没有相关说明。
+          required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 影响范围
+      description: 指出需要更新的文档位置或主题。
+      placeholder: 例如 README、教程章节、API 文档等。
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: 具体内容
+      description: 描述需要补充、修正或删除的内容，并说明原因。
+      placeholder: 详细说明当前文档的缺失或问题。
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: 参考资料
+      description: 提供相关链接、截图或其他支持信息。
+      placeholder: 可选，但越多越好。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest a new feature or improvement for Astris.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢提出想法！请描述期望功能及其价值，便于评估与规划。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 提交前请确认
+      options:
+        - label: 我已搜索现有 issues，确认没有重复建议。
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 功能概述
+      description: 简要说明你希望新增或改进的内容。
+      placeholder: 我希望……
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 背景与动机
+      description: 为什么需要此功能？它解决了什么问题？
+      placeholder: 介绍痛点或目标用户场景。
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 可能的实现方案
+      description: 分享任何实现思路、相关资料或设计草稿。
+      placeholder: 如果你有建议的实现方式，请在此说明。
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 替代方案与附加信息
+      description: 列出你考虑过的其他方案或补充信息。
+      placeholder: 还有什么我们需要知道的吗？
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add bug, feature request, and documentation improvement issue templates with required context
- disable blank issues and direct security reports to the security policy

## Testing
- `just ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cfde6bda38832a9b68c73bccaf2bd5