### PR TITLE
docs: add bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,64 +7,64 @@ body:
   - type: markdown
     attributes:
       value: |
-        感谢反馈问题！请尽量提供完整信息，帮助我们定位并复现。
+        感谢反馈问题！请尽量提供完整信息，帮助我们定位并复现。 / Thanks for reporting the issue! Please share as much detail as possible so we can identify and reproduce it.
   - type: checkboxes
     id: checks
     attributes:
-      label: 提交前请确认
+      label: 提交前请确认 / Before submitting, please confirm
       options:
-        - label: 我已搜索现有 issues，确认没有重复问题。
+        - label: 我已搜索现有 issues，确认没有重复问题。 / I have searched existing issues and confirmed this is not a duplicate.
           required: true
-        - label: 我在最新版（main 分支）或最近的发布版本上复现过此问题。
+        - label: 我在最新版（main 分支）或最近的发布版本上复现过此问题。 / I have reproduced this issue on the latest main branch or recent release.
           required: true
   - type: textarea
     id: summary
     attributes:
-      label: 简要描述
-      description: 简要说明遇到的问题及其影响。
-      placeholder: 描述问题的概况……
+      label: 简要描述 / Short summary
+      description: 简要说明遇到的问题及其影响。 / Provide a concise description of the issue and its impact.
+      placeholder: 描述问题的概况…… / Outline the problem at a high level…
     validations:
       required: true
   - type: textarea
     id: reproduction_steps
     attributes:
-      label: 复现步骤
-      description: 清晰列出如何复现问题的步骤。
+      label: 复现步骤 / Steps to reproduce
+      description: 清晰列出如何复现问题的步骤。 / List clear steps so we can reproduce the issue.
       placeholder: |
-        1. …
-        2. …
-        3. …
+        1. … / Step 1: …
+        2. … / Step 2: …
+        3. … / Step 3: …
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: 预期行为
-      description: 描述你期望发生的结果。
-      placeholder: 应该发生什么？
+      label: 预期行为 / Expected behavior
+      description: 描述你期望发生的结果。 / Describe what you expected to happen.
+      placeholder: 应该发生什么？ / What should happen?
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: 实际行为
-      description: 描述实际发生的结果，并附上必要的截图或日志。
-      placeholder: 实际发生了什么？
+      label: 实际行为 / Actual behavior
+      description: 描述实际发生的结果，并附上必要的截图或日志。 / Share what actually happened and attach screenshots or logs if needed.
+      placeholder: 实际发生了什么？ / What really happened?
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: 版本信息
-      description: 请提供 Astris 版本、平台（OS/架构）与运行特性（如 dev_native）。
-      placeholder: 例如：main (commit abc123)、Windows 11、dev_native
+      label: 版本信息 / Version details
+      description: 请提供 Astris 版本、平台（OS/架构）与运行特性（如 dev_native）。 / Provide the Astris version, platform (OS/architecture), and runtime features (e.g., dev_native).
+      placeholder: "例如：main (commit abc123)、Windows 11、dev_native / e.g. main (commit abc123), Windows 11, dev_native"
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: 附加上下文
-      description: 其他信息、日志、崩溃堆栈等。
-      placeholder: 如有更多线索，请在此补充。
+      label: 附加上下文 / Additional context
+      description: 其他信息、日志、崩溃堆栈等。 / Any other details, logs, or crash stacks.
+      placeholder: 如有更多线索，请在此补充。 / Share any further clues here.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
     url: https://github.com/astris-rs/astris/security/policy
-    about: 如果你发现安全问题，请按安全策略私下报告。
+    about: 如果你发现安全问题，请按安全策略私下报告。 / If you discover a security issue, please report it privately following our security policy.

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -7,35 +7,35 @@ body:
   - type: markdown
     attributes:
       value: |
-        文档对于分享知识至关重要，请提供足够的背景信息，便于我们更新内容。
+        文档对于分享知识至关重要，请提供足够的背景信息，便于我们更新内容。 / Documentation is vital for sharing knowledge—please give enough context so we can update it effectively.
   - type: checkboxes
     id: checks
     attributes:
-      label: 提交前请确认
+      label: 提交前请确认 / Before submitting, please confirm
       options:
-        - label: 我已搜索现有 issues 和文档，确认没有相关说明。
+        - label: 我已搜索现有 issues 和文档，确认没有相关说明。 / I have searched existing issues and docs to ensure this isn't already covered.
           required: true
   - type: textarea
     id: scope
     attributes:
-      label: 影响范围
-      description: 指出需要更新的文档位置或主题。
-      placeholder: 例如 README、教程章节、API 文档等。
+      label: 影响范围 / Scope of impact
+      description: 指出需要更新的文档位置或主题。 / Specify which documentation page or topic needs updates.
+      placeholder: 例如 README、教程章节、API 文档等。 / e.g. README, tutorial section, API docs, etc.
     validations:
       required: true
   - type: textarea
     id: details
     attributes:
-      label: 具体内容
-      description: 描述需要补充、修正或删除的内容，并说明原因。
-      placeholder: 详细说明当前文档的缺失或问题。
+      label: 具体内容 / Details
+      description: 描述需要补充、修正或删除的内容，并说明原因。 / Describe what should be added, fixed, or removed, and why.
+      placeholder: 详细说明当前文档的缺失或问题。 / Explain the current gaps or issues in detail.
     validations:
       required: true
   - type: textarea
     id: references
     attributes:
-      label: 参考资料
-      description: 提供相关链接、截图或其他支持信息。
-      placeholder: 可选，但越多越好。
+      label: 参考资料 / References
+      description: 提供相关链接、截图或其他支持信息。 / Share relevant links, screenshots, or other supporting info.
+      placeholder: 可选，但越多越好。 / Optional but the more the better.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,43 +7,43 @@ body:
   - type: markdown
     attributes:
       value: |
-        感谢提出想法！请描述期望功能及其价值，便于评估与规划。
+        感谢提出想法！请描述期望功能及其价值，便于评估与规划。 / Thanks for sharing your idea! Describe the desired feature and its value so we can evaluate and plan it.
   - type: checkboxes
     id: checks
     attributes:
-      label: 提交前请确认
+      label: 提交前请确认 / Before submitting, please confirm
       options:
-        - label: 我已搜索现有 issues，确认没有重复建议。
+        - label: 我已搜索现有 issues，确认没有重复建议。 / I have searched existing issues and confirmed this suggestion is not a duplicate.
           required: true
   - type: textarea
     id: summary
     attributes:
-      label: 功能概述
-      description: 简要说明你希望新增或改进的内容。
-      placeholder: 我希望……
+      label: 功能概述 / Feature summary
+      description: 简要说明你希望新增或改进的内容。 / Provide a brief overview of what you want added or improved.
+      placeholder: 我希望…… / I would like…
     validations:
       required: true
   - type: textarea
     id: motivation
     attributes:
-      label: 背景与动机
-      description: 为什么需要此功能？它解决了什么问题？
-      placeholder: 介绍痛点或目标用户场景。
+      label: 背景与动机 / Background and motivation
+      description: 为什么需要此功能？它解决了什么问题？ / Explain why this feature is needed and which problems it solves.
+      placeholder: 介绍痛点或目标用户场景。 / Describe the pain points or target user scenarios.
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: 可能的实现方案
-      description: 分享任何实现思路、相关资料或设计草稿。
-      placeholder: 如果你有建议的实现方式，请在此说明。
+      label: 可能的实现方案 / Possible solution
+      description: 分享任何实现思路、相关资料或设计草稿。 / Share implementation ideas, references, or draft designs.
+      placeholder: 如果你有建议的实现方式，请在此说明。 / If you have suggestions for implementation, describe them here.
     validations:
       required: false
   - type: textarea
     id: alternatives
     attributes:
-      label: 替代方案与附加信息
-      description: 列出你考虑过的其他方案或补充信息。
-      placeholder: 还有什么我们需要知道的吗？
+      label: 替代方案与附加信息 / Alternatives & additional context
+      description: 列出你考虑过的其他方案或补充信息。 / List any alternative approaches or extra details.
+      placeholder: 还有什么我们需要知道的吗？ / Anything else we should know?
     validations:
       required: false


### PR DESCRIPTION
## Summary
- add English translations alongside existing Chinese text in issue forms
- provide bilingual guidance for the security vulnerability contact link

## Testing
- python - <<'PY'
import yaml, pathlib
for path in sorted(pathlib.Path('.github/ISSUE_TEMPLATE').glob('*.yml')):
    try:
        with open(path, 'r', encoding='utf-8') as f:
            yaml.safe_load(f)
    except Exception as exc:
        print(f"{path}: ERROR {exc}")
    else:
        print(f"{path}: OK")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d011a5f2e0832a8184c9b0c5c75a2c